### PR TITLE
add mac build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "electron-builder": "^22.14.13",
+      "electron-builder": "^23.0.2",
     "electron": "^12.2.3"
   },
   "build": {
     "productName": "ScreenAreaShare",
+    "mac": {
+      "target": "dmg"
+    },
     "win": {
       "target": [
         "portable"


### PR DESCRIPTION
Tested , and works on Macbook Pro M1 Max
updated electron-builder version to 23.0.2 due to a dependency on python2 that has since been resolved
added the mac/target/dmg to the build config

on mac to build properly , run "npm run dist"

Thanks,   been looking for something like this this for ages.. 