### PR TITLE
allow negative x and y coordinates when placing the capture window

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ const createWindows = () => {
       enableRemoteModule: true,
       backgroundThrottling: false, // continue playing <video> element https://stackoverflow.com/a/68685080
     },
-    width: initCapRect.width,
-    height: initCapRect.height,
+    width: initRenderRect.width,
+    height: initRenderRect.height,
     frame: false,
     autoHideMenuBar: true,
     resizable: false,

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,11 @@ function checkWindowBounds(win) {
 }
 
 const createWindows = () => {
-  // Create the browser window.
+
+  //
+  // create and setup render window
+  //
+
   const mainWindow = new BrowserWindow({
     webPreferences: {
       nodeIntegration: true,
@@ -78,10 +82,14 @@ const createWindows = () => {
     autoHideMenuBar: true,
     resizable: false,
   });
+
+  // start by setting initial window location starting at (0,0) and change it
+  // later, when all other settings have been applied
   mainWindow.setPosition(
-    initRenderRect.x ?? mainWindow.getPosition()[0],
-    initRenderRect.y ?? mainWindow.getPosition()[1]
+    0,
+    0,
   );
+
   mainWindow.loadFile(path.join(__dirname, "render.html"));
   mainWindow.on("closed", () => app.quit());
   //mainWindow.setMenuBarVisibility(false)
@@ -99,7 +107,19 @@ const createWindows = () => {
   mainWindow.send("window-move", mainWindow.getBounds());
   mainWindow.on("moved", (event) => checkWindowBounds(mainWindow));
 
-  // capture window
+  // now, set the "real" location of the render window after all other
+  // settings have been done. hopefully, this eliminates electron's
+  // aversity about negative window coordinates
+  mainWindow.setPosition(
+    initRenderRect.x ?? mainWindow.getPosition()[0],
+    initRenderRect.y ?? mainWindow.getPosition()[1]
+  );
+
+
+  //
+  // create and setup capture window
+  // 
+
   const captureWindow = new BrowserWindow({
     webPreferences: {
       nodeIntegration: true,
@@ -174,6 +194,7 @@ const createWindows = () => {
       mainWindow.send("update-screen-to-capture", { display, sourceId });
     }
   }
+
 
   async function getVideoSourceIdForDisplay(display) {
     const inputSources = await desktopCapturer.getSources({

--- a/src/index.js
+++ b/src/index.js
@@ -112,10 +112,14 @@ const createWindows = () => {
     frame: false,
     opacity: freeze ? 0 : 0.6,
   });
+
+  // start by setting initial window location starting at (0,0) and change it
+  // later, when all other settings have been applied
   captureWindow.setPosition(
-    initCapRect.x ?? captureWindow.getPosition()[0],
-    initCapRect.y ?? captureWindow.getPosition()[1]
+    0,
+    0,
   );
+
   captureWindow.loadFile(path.join(__dirname, "capture.html"));
   captureWindow.setContentProtection(true); // exclude from capture
   captureWindow.setAlwaysOnTop(true);
@@ -123,6 +127,14 @@ const createWindows = () => {
   captureWindow.on("closed", () => app.quit());
   captureWindow.setIgnoreMouseEvents(freeze);
   //captureWindow.webContents.openDevTools();
+
+  // now, set the "real" location after all other settings have been done.
+  // hopefully, this eliminates electron's aversity about negative window
+  // coordinates
+  captureWindow.setPosition(
+    initCapRect.x ?? captureWindow.getPosition()[0],
+    initCapRect.y ?? captureWindow.getPosition()[1]
+  );
 
   captureWindow.on("resized", (event) => {
     checkWindowBounds(mainWindow);


### PR DESCRIPTION
The Electron framework seems to have problems when creating windows at negative origin locations. Negative locations will become significant when the user uses multiple monitors and does not configure the most left monitor as the main one. Locating windows on that monitor automatically results in negative coordinates, as the top left corner of the main window will be regarded as (0,0). By first, creating the render window at (0,0) and then doing all the other configurations and afterwards, set the desired location values (which might be negative ones) solves the conflict.